### PR TITLE
Fix, have previously failed

### DIFF
--- a/mathgenerator/__init__.py
+++ b/mathgenerator/__init__.py
@@ -40,7 +40,8 @@ def generate_context(seed = None):
         forward_words = _[2]
     else:
         forward_words = []
-    forward_words.extend(choice[0].split('_')).extend(choice[1].split('_'))
+    forward_words.extend(choice[0].split('_'))
+    forward_words.extend(choice[1].split('_'))
     problem = str(problem)
     solution = str(solution)
     try:


### PR DESCRIPTION
.extend(<content>).extend(<content>) failed on my python3.10
```Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mathgenerator
>>> mathgenerator.generate_context()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/clore/anaconda3/envs/3.10/lib/python3.10/site-packages/mathgenerator/__init__.py", line 44, in generate_context
    forward_words.extend(choice[0].split('_')).extend(choice[1].split('_'))
AttributeError: 'NoneType' object has no attribute 'extend'
```

This is a simple fix